### PR TITLE
aliased write to print

### DIFF
--- a/rb-src/lt_client.rb
+++ b/rb-src/lt_client.rb
@@ -155,6 +155,7 @@ class LtPrinter
       self.flush
     end
   end
+  alias_method :print, :write
 
   def flush
     client.send_response(client.currentId, "editor.eval.ruby.print", {"msg" => @cur, "file" => File.basename(FileUtils.pwd)})


### PR DESCRIPTION
Log4r console outputter calls `@out.print data` to write message and fails. This alias enables printing of log4r messages to LightTable's console.
