### PR TITLE
load project file when creating connection

### DIFF
--- a/rb-src/lt_client.rb
+++ b/rb-src/lt_client.rb
@@ -56,6 +56,15 @@ class LtClient < EM::Connection
     $stdout = LtPrinter.new(self)
     $stderr = LtPrinter.new(self)
     self.eval_queue = ""
+
+    load_project_file!(FileUtils.pwd)
+  end
+
+  def load_project_file!(dir)
+    file = "#{dir}/.lighttable"
+    load(file) if FileTest.exist?(file)
+  rescue => exp
+    logger.error "Error loading project file #{file}: #{exp.message}"
   end
 
   def receive_data(data)


### PR DESCRIPTION
If a .lighttable file exists in the root of the project, it will be evaluated when a connection is created. 
