### PR TITLE
Added several more extensions and filenames into :exts

### DIFF
--- a/ruby.behaviors
+++ b/ruby.behaviors
@@ -17,7 +17,7 @@
                    ]
      :editor.ruby.live [:lt.objs.langs.ruby/eval-on-change]
 
-     :files [(:lt.objs.files/file-types [{:name "Ruby" :exts [:rb] :mime "text/x-ruby" :tags [:editor.ruby]}])]
+     :files [(:lt.objs.files/file-types [{:name "Ruby" :exts [:rb, :gemspec, :Rakefile, :Gemfile] :mime "text/x-ruby" :tags [:editor.ruby]}])]
      :ruby.lang [:lt.objs.langs.ruby/eval! :lt.objs.langs.ruby/connect]}
 
 ;;  :- {:editor.ruby [:lt.plugins.watches/eval-on-watch-or-unwatch]}


### PR DESCRIPTION
Specifically, added :gemspec, :Rakefile and :Gemfile
Last two won't work on current LightTable release (0.6.2) but won't
break anything either. LightTable supports entire filenames as type
patterns as of commit [b5ec8d7](https://github.com/LightTable/LightTable/commit/b5ec8d7e0bacbc6b99f269e90c16ead366f6cdf6).
