### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ Thanks also to my employer, [Green River](http://www.greenriver.com) for support
 
 - Initial release with eval for whole files and selections
 
-###License
+### License
 
 Copyright (C) 2014 Rafe Rosen
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
